### PR TITLE
Fix: bgm 재생 오류 수정

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,9 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { RouterProvider } from 'react-router-dom'
 import router from './router'
-import BgmManager from './components/setting/BgmManager'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BgmManager />
     <RouterProvider router={router} />
   </StrictMode>,
 )

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -13,6 +13,10 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
+        path: '/',
+        element: <Onboarding />,
+      },
+      {
         path: '/onboarding',
         element: <Onboarding />,
       },


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
어제 말씀해주신 BGM 재생 오류를 확인하여 라우터 수정 및 main.jsx에 있던 BgmManager를 제거하여 문제를 해결했습니다. 기존에는 라우터의 기본 "/" 경로가 App을 렌더링하고, App뿐 아니라 Main에도 BgmManager가 함께 적용되어 중복 마운트가 발생한 것이 원인으로 보입니다.

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
